### PR TITLE
헤로쿠 DB 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,6 +35,6 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_TEAL_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
clearDB -> jawsDB
clearDB는 mySQL 5.6이 기본 버전으로 너무 낮음.
jawsDB는 mySQL 8.0이 기본 버전으로 적합함.

this closes #50 